### PR TITLE
Change text style does not invoke auto scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import {Angular2AutoScroll} from "angular2-auto-scroll/lib/angular2-auto-scroll.
  
 Argument passed to `lock-y-offset` is bottom offset of scroll position in pixels after scroll container stops auto scroll. Default value is 10.
 
-`observe-attributes` enable listen on attributes changes for example detect changes in font size.
+`observe-attributes` enable listening on attributes changes for example detect changes in font size.
 ## Building
 
 ```

--- a/README.md
+++ b/README.md
@@ -21,13 +21,16 @@ import {Angular2AutoScroll} from "angular2-auto-scroll/lib/angular2-auto-scroll.
 #### In template:
 
 ```html
-<div angular2-auto-scroll="50">
+<div angular2-auto-scroll lock-y-offset="10" observe-attributes>
     <div *ngFor="let message of messages">{{ message }}</div>
 </div>
 ```
 
-Argument passed to directive is bottom offset of scroll position in pixels after scroll container stops auto scroll. Default value is 10.
+#### Atribiutes:
+ 
+Argument passed to `lock-y-offset` is bottom offset of scroll position in pixels after scroll container stops auto scroll. Default value is 10.
 
+`observe-attributes` enable listen on attributes changes for example detect changes in font size.
 ## Building
 
 ```

--- a/src/angular2-auto-scroll.directive.ts
+++ b/src/angular2-auto-scroll.directive.ts
@@ -1,20 +1,26 @@
-import {Directive, ElementRef, HostListener, AfterContentInit, Input, OnDestroy} from '@angular/core';
+import {Directive, ElementRef, HostListener, AfterContentInit, Input, OnDestroy} from "@angular/core";
 
 @Directive({
-    selector: '[angular2-auto-scroll]',
+    selector: '[angular2-auto-scroll]'
 })
 export class Angular2AutoScroll implements AfterContentInit, OnDestroy {
     @Input('angular2-auto-scroll') lockYOffset = 10;
 
+    @Input() set observeAttributes(observeAttributes: boolean) {
+        this._observeAttributes = observeAttributes || false;
+    }
+
     private nativeElement: HTMLElement;
     private isLocked = false;
     private mutationObserver: MutationObserver;
+    private _observeAttributes: boolean = false;
 
     constructor(element: ElementRef) {
         this.nativeElement = element.nativeElement;
     }
 
-    @HostListener('scroll') private scrollHandler() {
+    @HostListener('scroll')
+    private scrollHandler() {
         const scrollFromBottom = this.nativeElement.scrollHeight - this.nativeElement.scrollTop - this.nativeElement.clientHeight;
         this.isLocked = scrollFromBottom > this.lockYOffset;
     }
@@ -25,7 +31,11 @@ export class Angular2AutoScroll implements AfterContentInit, OnDestroy {
                 this.nativeElement.scrollTop = this.nativeElement.scrollHeight;
             }
         });
-        this.mutationObserver.observe(this.nativeElement, {childList: true, subtree: true});
+        this.mutationObserver.observe(this.nativeElement, {
+            childList: true,
+            subtree: true,
+            attributes: this._observeAttributes
+        });
     }
 
     ngOnDestroy() {

--- a/src/angular2-auto-scroll.directive.ts
+++ b/src/angular2-auto-scroll.directive.ts
@@ -4,16 +4,12 @@ import {Directive, ElementRef, HostListener, AfterContentInit, Input, OnDestroy}
     selector: '[angular2-auto-scroll]'
 })
 export class Angular2AutoScroll implements AfterContentInit, OnDestroy {
-    @Input('angular2-auto-scroll') lockYOffset = 10;
-
-    @Input() set observeAttributes(observeAttributes: boolean) {
-        this._observeAttributes = observeAttributes || false;
-    }
+    @Input('lock-y-offset') lockYOffset = 10;
+    @Input('observe-attributes') observeAttributes: boolean = false;
 
     private nativeElement: HTMLElement;
     private isLocked = false;
     private mutationObserver: MutationObserver;
-    private _observeAttributes: boolean = false;
 
     constructor(element: ElementRef) {
         this.nativeElement = element.nativeElement;
@@ -34,7 +30,7 @@ export class Angular2AutoScroll implements AfterContentInit, OnDestroy {
         this.mutationObserver.observe(this.nativeElement, {
             childList: true,
             subtree: true,
-            attributes: this._observeAttributes
+            attributes: this.observeAttributes
         });
     }
 


### PR DESCRIPTION
Added new attribute that extends observer config to watch element attributes changes.

`<div class="list" angular2-auto-scroll lock-y-offset="10" observe-attributes >...</div>
`
